### PR TITLE
Fix nvm install LTS command

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -37,8 +37,7 @@ fi
 # Install NVM for easier Node.js version management
 printf "\n${GREEN}Installing NVM for easier Node.js version management...${NORMAL}\n"
 eval "curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.2/install.sh | bash"
-eval "nvm install node --lts"
-eval "nvm alias default node"
+eval "nvm install --lts"
 
 # Install Yarn for easier (and faster) Node.js dependency management
 printf "\n${BLUE}Installing Yarn for easier (and faster) Node.js dependency management...${NORMAL}\n"


### PR DESCRIPTION
- Fixes `nvm install` command to actually install the LTS version (`nvm install node --lts` was installing current, not LTS)
- Removes the `nvm alias default node` line because it doesn't work with `nvm install --lts`... according to the NVM docs, the first version installed becomes the default so removing it should be fine